### PR TITLE
Add node-canvas dependencies to alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,26 @@ FROM nginx:alpine AS production-nginx
 COPY --from=production-build /app/web-dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 
-FROM node:18.17-alpine AS production-backend
+FROM node:18.17-alpine AS alpine-node-base
 
 RUN apk update && apk add chromium
+
+# node-canvas dependencies
+RUN apk add --no-cache --virtual .build-deps \
+  git \
+  build-base \
+  g++ \
+  cairo-dev \
+  jpeg-dev \
+  pango-dev \
+  giflib-dev \
+  && apk add --no-cache --virtual .runtime-deps \
+  cairo \
+  jpeg \
+  pango \
+  giflib
+
+FROM alpine-node-base AS production-backend
 
 COPY --from=production-build /app/build /app/build
 COPY --from=production-build /app/backend /app/backend
@@ -34,9 +51,7 @@ WORKDIR /app
 
 CMD ["yarn", "start"]
 
-FROM node:18 AS development
-
-RUN apt-get update && apt-get install -y chromium
+FROM alpine-node-base AS development
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Makes dev run on same alpine image as production to catch these mistakes earlier; to help with build times, a middle common base layer is added (thanks @dogamak for the suggestion)