### PR TITLE
Allow debtors to mark their own debts as paid

### DIFF
--- a/packages/backend/src/modules/debts/api.ts
+++ b/packages/backend/src/modules/debts/api.ts
@@ -787,6 +787,25 @@ const factory: RouterFactory = route => {
       return ok(debts);
     });
 
+  const markAsPaid = route
+    .use(auth({ accessLevel: 'normal' }))
+    .use(
+      Parser.body(
+        t.type({
+          paid: t.boolean,
+        }),
+      ),
+    )
+    .post('/:id/mark')
+    .handler(async ({ bus, body, routeParams }) => {
+      await bus.exec(debtService.markAsPaid, {
+        paymentId: routeParams.id,
+        paid: body.paid,
+      });
+
+      return ok();
+    });
+
   return router(
     sendAllReminders,
     createDebtComponent,
@@ -806,6 +825,7 @@ const factory: RouterFactory = route => {
     updateMultipleDebts,
     getDebtsByEmail,
     getDebtsByTag,
+    markAsPaid,
   );
 };
 

--- a/packages/backend/src/modules/debts/definitions.ts
+++ b/packages/backend/src/modules/debts/definitions.ts
@@ -165,6 +165,13 @@ const iface = createInterface('debts', builder => ({
     ]),
     response: types.payment,
   }),
+  markAsPaid: builder.proc({
+    payload: t.type({
+      paid: t.boolean,
+      paymentId: t.string,
+    }),
+    response: t.void,
+  }),
 }));
 
 export default iface;
@@ -183,6 +190,7 @@ export const {
   updateDebtComponent,
   getDebtsByPayer,
   createPayment,
+  markAsPaid,
 } = iface.procedures;
 
 const scope = createScope('debts');

--- a/packages/backend/src/modules/debts/index.ts
+++ b/packages/backend/src/modules/debts/index.ts
@@ -297,41 +297,7 @@ export default createModule({
         });
       },
 
-      async createDebt(
-        { debt, options },
-        { pg },
-        bus,
-      ): Promise<{
-        id: string;
-        humanId: string;
-        accountingPeriod: number;
-        name: string;
-        tags: { name: string; hidden: boolean }[];
-        date: Date | null;
-        lastReminded: Date | null;
-        dueDate: Date | null;
-        draft: boolean;
-        publishedAt: Date | null;
-        payerId: { type: 'internal'; value: string };
-        debtCenterId: string;
-        description: string;
-        createdAt: Date;
-        updatedAt: Date;
-        status: 'paid' | 'unpaid' | 'mispaid';
-        paymentCondition: number | null;
-        defaultPayment: string | null;
-        credited: boolean;
-        total: { currency: 'eur'; value: number };
-        debtComponents: {
-          id: string;
-          name: string;
-          amount: { currency: 'eur'; value: number };
-          description: string;
-          debtCenterId: string;
-          createdAt: Date | null;
-          updatedAt: Date | null;
-        }[];
-      }> {
+      async createDebt({ debt, options }, { pg }, bus) {
         const payerProfile = await bus.exec(
           payerService.getPayerProfileByIdentity,
           debt.payer,
@@ -538,6 +504,18 @@ export default createModule({
         }
 
         return result.right;
+      },
+
+      async markAsPaid({ paid, paymentId }, { pg }) {
+        if (paid) {
+          await pg.do(
+            sql`UPDATE debt SET marked_as_paid = NOW() WHERE id = ${paymentId}`,
+          );
+        } else {
+          await pg.do(
+            sql`UPDATE debt SET marked_as_paid = NULL WHERE id = ${paymentId}`,
+          );
+        }
       },
     });
 
@@ -991,6 +969,7 @@ export default createModule({
               date: null,
               name: details.title,
               description: details.description,
+              markedAsPaid: null,
               draft: true,
               publishedAt: null,
               debtCenterId: debtCenter.id,

--- a/packages/backend/src/modules/debts/query.ts
+++ b/packages/backend/src/modules/debts/query.ts
@@ -77,6 +77,7 @@ export const formatDebt = (
       : formatPayerProfile(debt.payer)),
   status: debt.status,
   tags: (debt.tags ?? []).map(formatDebtTag),
+  markedAsPaid: debt.marked_as_paid ?? null,
 });
 
 export const formatDebtComponent = (

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -545,6 +545,7 @@ export type DbDebt = {
   date: Date | null;
   last_reminded: Date | null;
   due_date: Date | null;
+  marked_as_paid: Date | null;
   draft: boolean;
   published_at: Date | null;
   payer_id: string;
@@ -574,6 +575,7 @@ export const debt = t.type({
   tags: t.array(debtTag),
   date: nullable(tt.date),
   lastReminded: nullable(tt.date),
+  markedAsPaid: nullable(tt.date),
   dueDate: nullable(tt.date),
   draft: t.boolean,
   publishedAt: nullable(tt.date),

--- a/packages/frontend/i18n/en.json
+++ b/packages/frontend/i18n/en.json
@@ -134,14 +134,17 @@
       "paid": "Paid",
       "unpaid": "Unpaid",
       "mispaid": "Mispaid",
-      "overdue": "Overdue"
+      "overdue": "Overdue",
+      "markedAsPaid": "Marked as paid"
     },
     "debtCard": {
       "amountLabel": "Amount",
       "dateLabel": "Date",
       "dueDateLabel": "Due Date",
       "payButton": "Pay now",
-      "detailsButton": "View details"
+      "detailsButton": "View details",
+      "markAsPaid": "Mark as paid",
+      "markAsUnpaid": "Mark as unpaid"
     },
     "paymentCard": {
       "typeLabel": "Payment method",

--- a/packages/frontend/i18n/fi.json
+++ b/packages/frontend/i18n/fi.json
@@ -134,14 +134,17 @@
       "paid": "Maksettu",
       "unpaid": "Maksamatta",
       "mispaid": "Maksuvirhe",
-      "overdue": "Myöhässä"
+      "overdue": "Myöhässä",
+      "markedAsPaid": "Merkitty maksetuksi"
     },
     "debtCard": {
       "amountLabel": "Summa",
       "dateLabel": "Päiväys",
       "dueDateLabel": "Eräpäivä",
       "payButton": "Maksa",
-      "detailsButton": "Lisätiedot"
+      "detailsButton": "Lisätiedot",
+      "markAsPaid": "Merkitse maksetuksi",
+      "markAsUnpaid": "Merkitse maksamattomaksi"
     },
     "paymentCard": {
       "typeLabel": "Maksutapa",

--- a/packages/frontend/src/api/debt.ts
+++ b/packages/frontend/src/api/debt.ts
@@ -260,6 +260,15 @@ const debtApi = rtkApi.injectEndpoints({
       providesTags: result =>
         (result ?? []).map(({ id }) => ({ type: 'Debt' as const, id })),
     }),
+
+    markAsPaid: builder.mutation<void, { id: string; paid: boolean }>({
+      query: ({ id, paid }) => ({
+        method: 'POST',
+        url: `/debt/${id}/mark`,
+        body: { paid },
+      }),
+      invalidatesTags: (_, __, { id }) => [{ type: 'Debt', id }],
+    }),
   }),
 });
 
@@ -286,6 +295,7 @@ export const {
   useMassCreateDebtsProgressQuery,
   useUpdateDebtComponentMutation,
   useGetDebtsByEmailQuery,
+  useMarkAsPaidMutation,
 } = debtApi;
 
 export default debtApi;

--- a/packages/frontend/src/components/debt-status-badge.tsx
+++ b/packages/frontend/src/components/debt-status-badge.tsx
@@ -23,5 +23,14 @@ export const DebtStatusBadge = ({ debt }: { debt: Debt }) => {
     status = 'overdue';
   }
 
-  return <span className={debtStatusBadgeCva({ status })}>{t(status)}</span>;
+  return (
+    <div className="inline-flex gap-2">
+      {debt.markedAsPaid && debt.status !== 'paid' && (
+        <span className={debtStatusBadgeCva({ status: 'paid' })}>
+          {t('markedAsPaid')}
+        </span>
+      )}
+      <span className={debtStatusBadgeCva({ status })}>{t(status)}</span>
+    </div>
+  );
 };

--- a/packages/frontend/src/views/admin/debt-details.tsx
+++ b/packages/frontend/src/views/admin/debt-details.tsx
@@ -208,6 +208,11 @@ export const DebtDetails = ({ params }: Props) => {
           </Field>
         )}
         <BadgeField label="Status" {...statusBadge} />
+        <Field label="Marked as paid">
+          {debt.markedAsPaid === null
+            ? 'Not marked as paid'
+            : format(new Date(debt.markedAsPaid), 'dd.MM.yyyy HH:mm')}
+        </Field>
         <TextField fullWidth label="Description" value={debt.description} />
       </Section>
       <Section title="Content">

--- a/packages/frontend/src/views/public/debts.tsx
+++ b/packages/frontend/src/views/public/debts.tsx
@@ -14,6 +14,7 @@ import { useGetInfoQuery } from '../../api/banking/statements';
 import { useMemo } from 'react';
 import { DebtStatusBadge } from '../../components/debt-status-badge';
 import React from 'react';
+import { useMarkAsPaidMutation } from '../../api/debt';
 
 const debtCardCva = cva(
   'rounded-md border shadow-md shadow-black/5 bg-white/60',
@@ -33,6 +34,14 @@ type CardProps = {
 
 const DebtCard: React.FC<CardProps> = ({ debt }) => {
   const { t } = useTranslation([], { keyPrefix: 'debtCard' });
+  const [markAsPaid] = useMarkAsPaidMutation();
+
+  const togglePaidMark = () => {
+    markAsPaid({
+      id: debt.id,
+      paid: !debt.markedAsPaid,
+    });
+  };
 
   return (
     <div className={debtCardCva({ selected: false })}>
@@ -81,6 +90,13 @@ const DebtCard: React.FC<CardProps> = ({ debt }) => {
         >
           {t('detailsButton')}
         </Link>
+        <div className="grow" />
+        <button
+          className="px-2 py-1 text-sm font-bold uppercase text-zinc-400 hover:bg-zinc-50"
+          onClick={togglePaidMark}
+        >
+          {debt.markedAsPaid ? t('markAsUnpaid') : t('markAsPaid')}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR implements a "Mark as paid" feature, which allows users to mark their own debts as paid. The marking is only for the user to keep note of which debts they have already paid, and does not affect the debt's status in the system. The treasurer can also see if users have marked their debt's as paid.