### PR TITLE
Fix sidebar behavior on screens exactly 1280px wide

### DIFF
--- a/packages/frontend/src/views/admin/index.tsx
+++ b/packages/frontend/src/views/admin/index.tsx
@@ -207,7 +207,7 @@ const Admin = () => {
         evt.target &&
         sidebarRef.current &&
         !sidebarRef.current.contains(evt.target as Node) &&
-        window.matchMedia('(max-width: 1280px)').matches
+        window.matchMedia('(max-width: 1279px)').matches
       ) {
         setSidebarOpen(false);
       }


### PR DESCRIPTION
Previously when using a screen exactly 1280px wide (which is the default for Playwright), the sidebar would display by default and not hover over the page content, but mouse clicks on the page content would cause the sidebar to retract.

Automatic sidebar retraction should only occur when the screen is less than 1280px wide, as this coincides with the CSS breakpoint which causes the sidebar to float above the page content.

This hopefully helps with some of the test flakiness as well.