### PR TITLE
Better payers table

### DIFF
--- a/packages/backend/src/modules/debts/index.ts
+++ b/packages/backend/src/modules/debts/index.ts
@@ -659,6 +659,7 @@ export default createModule({
               totalPaid: null,
               primaryEmail: null,
               paidRatio: 0,
+              unpaidValue: cents(0),
             };
           } else {
             return await bus.exec(
@@ -688,6 +689,7 @@ export default createModule({
               mergedTo: null,
               primaryEmail: null,
               paidRatio: 0,
+              unpaidValue: cents(0),
             };
           } else {
             const payer = await bus.exec(

--- a/packages/backend/src/modules/payers/index.ts
+++ b/packages/backend/src/modules/payers/index.ts
@@ -82,7 +82,7 @@ const baseQuery = createPaginatedQuery<DbPayerProfile>(
   WITH counts AS (
     SELECT
       d.payer_id,
-      COUNT(DISTINCT d.id) AS debt_count,
+      COUNT(DISTINCT d.id) FILTER (WHERE d.published_at IS NOT NULL AND NOT d.credited) AS debt_count,
       COUNT(DISTINCT d.id) FILTER (WHERE ds.is_paid) AS paid_count,
       COUNT(DISTINCT d.id) FILTER (WHERE NOT ds.is_paid AND d.published_at IS NOT NULL AND NOT d.credited) AS unpaid_count
     FROM debt d
@@ -91,7 +91,7 @@ const baseQuery = createPaginatedQuery<DbPayerProfile>(
   ), totals AS (
     SELECT
       d.payer_id,
-      COALESCE(SUM(dco.amount), 0) AS total,
+      COALESCE(SUM(dco.amount) FILTER (WHERE d.published_at IS NOT NULL AND NOT d.credited), 0) AS total,
       COALESCE(SUM(dco.amount) FILTER (WHERE ds.is_paid), 0) AS total_paid,
       COALESCE(SUM(dco.amount) FILTER (WHERE NOT ds.is_paid AND d.published_at IS NOT NULL AND NOT d.credited), 0) AS unpaid_value
     FROM debt d

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -284,6 +284,7 @@ export type DbPayerProfile = {
   total?: number;
   total_paid?: number;
   paid_ratio?: number;
+  unpaid_value?: number;
 };
 
 export const payerProfile = t.type({
@@ -302,6 +303,7 @@ export const payerProfile = t.type({
   emails: t.array(payerEmail),
   primaryEmail: nullable(t.string),
   paidRatio: t.number,
+  unpaidValue: nullable(euroValue),
 });
 
 export type PayerProfile = t.TypeOf<typeof payerProfile>;

--- a/packages/frontend/src/views/admin/payer-listing.tsx
+++ b/packages/frontend/src/views/admin/payer-listing.tsx
@@ -200,6 +200,14 @@ export const PayerListing = () => {
             render: value => formatEuro(cents(value)),
           },
           {
+            name: 'Unpaid value',
+            key: 'unpaid_value',
+            getValue: row => row.unpaidValue ?? cents(0),
+            align: 'right',
+            compareBy: value => value.value,
+            render: value => formatEuro(value),
+          },
+          {
             name: 'Total value',
             key: 'total',
             getValue: row => row.total?.value ?? 0,

--- a/packages/frontend/src/views/admin/payer-listing.tsx
+++ b/packages/frontend/src/views/admin/payer-listing.tsx
@@ -181,13 +181,13 @@ export const PayerListing = () => {
             ),
           },
           {
-            name: 'Paid',
+            name: 'Paid debts',
             key: 'paid_count',
             getValue: 'paidCount',
             align: 'right',
           },
           {
-            name: 'Debts Count',
+            name: 'Total debts',
             key: 'debt_count',
             getValue: 'debtCount',
             align: 'right',


### PR DESCRIPTION
- Add "Unpaid value" column to the payers table
- Do not count unpulished or credited debts in the statistics
- Rename columns
