### PR TITLE
Clean up orphaned jobs stuck in `processing` state

### DIFF
--- a/packages/backend/migrations/1737496379731_add-job-lock-id.sql
+++ b/packages/backend/migrations/1737496379731_add-job-lock-id.sql
@@ -1,0 +1,7 @@
+-- Up Migration
+
+ALTER TABLE jobs ADD COLUMN lock_id SERIAL NOT NULL;
+
+-- Down Migration
+
+ALTER TABLE jobs DROP COLUMN lock_id;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1250,6 +1250,7 @@ export const dbJob = t.type({
   rate: t.Integer,
   next_poll: nullable(tt.date),
   progress: Percentage,
+  lock_id: t.Integer,
 });
 
 export const job = t.type({
@@ -1275,6 +1276,7 @@ export const job = t.type({
   rate: t.Integer,
   nextPoll: nullable(tt.date),
   progress: Percentage,
+  lockId: t.Integer,
 });
 
 export type DbJob = t.TypeOf<typeof dbJob>;
@@ -1302,4 +1304,5 @@ export type Job<D = unknown, R = unknown> = {
   concurrency: number;
   nextPoll: Date | null;
   progress: number;
+  lockId: number;
 };

--- a/packages/frontend/src/api/jobs.ts
+++ b/packages/frontend/src/api/jobs.ts
@@ -31,6 +31,7 @@ type ResponseJob = {
   nextPoll: string | null;
   progress: number;
   triggeredBy: InternalIdentity | null;
+  lockId: number;
 };
 
 const transformJob = (job: ResponseJob): Job => ({
@@ -56,6 +57,7 @@ const transformJob = (job: ResponseJob): Job => ({
   nextPoll: job.nextPoll ? parseISO(job.nextPoll) : null,
   progress: job.progress,
   triggeredBy: job.triggeredBy,
+  lockId: job.lockId,
 });
 
 const jobsApi = rtkApi.injectEndpoints({


### PR DESCRIPTION
Employs PostgreSQL advisory locks to detect abandoned jobs. Jobs can become abandoned if the backend restarts, the database connection is interrupted or the database itself is restarted during job execution.