### PR TITLE
Implement horizontal scroll for tables

### DIFF
--- a/packages/frontend/src/components/debt-list.tsx
+++ b/packages/frontend/src/components/debt-list.tsx
@@ -59,7 +59,7 @@ export const DebtList = <Q extends PaginatedBaseQuery>(props: Props<Q>) => {
         key: 'name',
         name: 'Name',
         getValue: 'name',
-        width: 'minmax(min-content, 1fr)',
+        width: '1fr',
         filter: {
           search: true,
           pushdown: true,

--- a/packages/frontend/src/components/email-list.tsx
+++ b/packages/frontend/src/components/email-list.tsx
@@ -25,7 +25,7 @@ export const EmailList = <Q extends PaginatedBaseQuery>(props: Props<Q>) => {
           name: 'Recipient',
           key: 'recipient',
           getValue: 'recipient',
-          width: 'minmax(auto, 17.5em)',
+          width: '17.5em',
           filter: {
             search: true,
             pushdown: true,

--- a/packages/frontend/src/components/transaction-list.tsx
+++ b/packages/frontend/src/components/transaction-list.tsx
@@ -92,7 +92,6 @@ export const TransactionList = <Q extends PaginatedBaseQuery>(
           pushdown: true,
         },
         getValue: tx => tx.otherParty?.name,
-        width: 'minmax(min-content, auto)',
       },
       {
         name: 'Reference',
@@ -102,7 +101,6 @@ export const TransactionList = <Q extends PaginatedBaseQuery>(
           pushdown: true,
         },
         getValue: tx => tx.reference ?? '',
-        width: 'minmax(min-content, auto)',
       },
       {
         name: 'Message',

--- a/packages/ui/src/dropdown.tsx
+++ b/packages/ui/src/dropdown.tsx
@@ -251,64 +251,66 @@ const DropdownComponent = forwardRef<
               />
             )}
           </button>
-          <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
-            <FloatingPortal>
-              <FloatingFocusManager modal={false} context={context}>
-                <div
-                  ref={refs.setFloating}
-                  style={{
-                    ...floatingStyles,
-                    display: isOpen ? floatingStyles.display : 'none',
-                  }}
-                  className="relative z-50 min-w-[13em] overflow-hidden rounded-md border bg-white shadow-sm"
-                  {...getFloatingProps()}
-                >
-                  {searchable && (
-                    <Search
-                      value={search}
-                      onInput={evt => {
-                        setSearch(evt.currentTarget.value);
-                        onSearchChange?.(evt.currentTarget.value);
-                      }}
-                    />
-                  )}
+          {isOpen && (
+            <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
+              <FloatingPortal>
+                <FloatingFocusManager modal={false} context={context}>
                   <div
-                    className={`flex w-full flex-col items-stretch p-1 text-sm ${scroll && 'max-h-[15em] overflow-y-auto'}`}
+                    ref={refs.setFloating}
+                    style={{
+                      ...floatingStyles,
+                      display: isOpen ? floatingStyles.display : 'none',
+                    }}
+                    className="relative z-50 min-w-[13em] overflow-hidden rounded-md border bg-white shadow-sm"
+                    {...getFloatingProps()}
                   >
-                    {children}
-                    {options?.map(option => {
-                      if ('divider' in option && option.divider) {
-                        return <div />;
-                      }
-
-                      if (
-                        typeof option.text === 'object' &&
-                        option.text !== null &&
-                        'type' in option.text &&
-                        option.text.type === Dropdown
-                      ) {
-                        return option.text;
-                      }
-
-                      return (
-                        <DropdownItem
-                          value={option.value}
-                          label={option.text}
-                          aside={option.label}
-                          onSelect={option.onSelect}
-                        />
-                      );
-                    })}
-                    {noMatches && (
-                      <div className="mx-2 py-1 text-sm text-gray-500">
-                        No matches!
-                      </div>
+                    {searchable && (
+                      <Search
+                        value={search}
+                        onInput={evt => {
+                          setSearch(evt.currentTarget.value);
+                          onSearchChange?.(evt.currentTarget.value);
+                        }}
+                      />
                     )}
+                    <div
+                      className={`flex w-full flex-col items-stretch p-1 text-sm ${scroll && 'max-h-[15em] overflow-y-auto'}`}
+                    >
+                      {children}
+                      {options?.map(option => {
+                        if ('divider' in option && option.divider) {
+                          return <div />;
+                        }
+
+                        if (
+                          typeof option.text === 'object' &&
+                          option.text !== null &&
+                          'type' in option.text &&
+                          option.text.type === Dropdown
+                        ) {
+                          return option.text;
+                        }
+
+                        return (
+                          <DropdownItem
+                            value={option.value}
+                            label={option.text}
+                            aside={option.label}
+                            onSelect={option.onSelect}
+                          />
+                        );
+                      })}
+                      {noMatches && (
+                        <div className="mx-2 py-1 text-sm text-gray-500">
+                          No matches!
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </FloatingFocusManager>
-            </FloatingPortal>
-          </FloatingList>
+                </FloatingFocusManager>
+              </FloatingPortal>
+            </FloatingList>
+          )}
         </DropdownContext.Provider>
       </FloatingNode>
     );


### PR DESCRIPTION
In order to keep the headers as sticky, they needed to be moved outside of the scrolling container. This means that their scroll position and sizing needs to be synchronized using javascript. This might cause some issues or lag, but we'll see. 

Resolves #134